### PR TITLE
日付文字列の作成方法を修正する。

### DIFF
--- a/scripts/reminder.coffee
+++ b/scripts/reminder.coffee
@@ -13,10 +13,10 @@ module.exports = (robot) ->
   new CronJob
     cronTime: '0 0 12 * * *'
     onTick: ->
-      nowDate = new Date()
-      nowYear = nowDate.getYear()
-      nowMonth = nowDate.getMonth() + 1
-      nowDay = nowDate.getDate()
+      dt = new Date()
+      nowYear = dt.getFullYear()
+      nowMonth = dt.getMonth() + 1
+      nowDate = dt.getDate()
       dateStr = "#{nowYear}年#{nowMonth}月#{nowDate}日"
       robot.send envelope, "#{dateStr}の正午です。"
     start: true


### PR DESCRIPTION
- 年を得るためには`getYear`ではなく、`getFullYear`を使う。
- `nowDate`と`getDate`と紛らわしかったため、変数の命名方法を修正した。